### PR TITLE
Resolved mktemp bug on OS X and implemented better vi-like keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ But any image files that Imagemagick can convert to png should be displayed.
 
 While viewing a file, the default key commands are:
 
-       [count]j     page back
-       [count]k     page forward
+       [count]k     page back
+       [count]j     page forward
        enter/space  page forward
-       J/K:         previous document/next document
+       K/J:         previous document/next document
        [count]g:    go to page number [count]
        gg:          go to first page
        g'[mark]     go to page stored in [mark]

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Installation
 ============
 
 `termpdf` is a bash script. Put it somewhere in your path and make sure it has
-the appropriate permissions (i.e., `chmod u+x termpdf`).
-
+the appropriate permissions (i.e., `chmod u+x termpdf`). 
 Dependencies:
 
 -   w3m (for X11) or iTerm2 2.9 or greater (for OS X)
@@ -41,6 +40,10 @@ Dependencies:
 On OSX, install these via homebrew with
 
     brew install gs imagemagick poppler pdfgrep djvulibre selecta
+
+`termpdf` requires at least Bash 4.0 to run, so you may need to upgrade it with
+
+	brew install bash
 
 On Ubuntu, you will need to download selecta and put it in your path.
 Everything else can be installed via apt-get with

--- a/termpdf
+++ b/termpdf
@@ -32,10 +32,10 @@ text_pagers[1]='less -XFRE' # secondary pager is 'less'
 #
 declare -A keys
 keys=(
-  ["next-page"]="k"
-  ["previous-page"]="j"
-  ["next-doc"]="K"
-  ["previous-doc"]="J"
+  ["next-page"]="j"
+  ["previous-page"]="k"
+  ["next-doc"]="J"
+  ["previous-doc"]="K"
   ["goto-page"]="g"
   ["goto-last"]="G"
   ["refresh-view"]="r"
@@ -1155,7 +1155,7 @@ done
 
 
 # Make a tmp_dir
-tmp_dir=$(mktemp -d)
+tmp_dir="$(mktemp -q -d -t "termpdftemp.XXXXXX" 2>/dev/null || mktemp -q -d)"
 # Check to see that a file was specified on the cli
 if [[ ${#files[@]} == 0 ]]; then 
     get_pane_size


### PR DESCRIPTION
Fixes #3 using solution given [here](http://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x).
