### PR TITLE
Clear image before drawing new one to prevent pages of different sizes being drawn over each other

### DIFF
--- a/termpdf
+++ b/termpdf
@@ -75,6 +75,7 @@ function print_image_iterm() {
 }
 
 function print_image_kitty() {
+   $kitty icat --clear
    $kitty icat $kitty_opts --place "${width}x${height}@0x0" "$1"
 }
 


### PR DESCRIPTION
Screenshot of the problem below:
![screenshot from 2018-08-24 15-13-17](https://user-images.githubusercontent.com/5357642/44589368-53fd6c00-a7b0-11e8-8780-486efd741401.png)
Note that this does introduce a moment where there is no image and so the screen flashes black.
